### PR TITLE
Test : Auth, User 테스트 코드 추가

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,18 +1,224 @@
+import { User } from './../user/entity/user.entity';
+import { UserRepository } from './../user/repository/user.repository';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthService } from './auth.service';
+import { AuthService, JwtPayload } from './auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { AccessTokenDto } from './dto/access-token.dto';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
+
+// DB 의존성 Mock
+class MockUserRepository {
+  save = jest.fn();
+  findUserBy = jest.fn();
+  isExist = jest.fn();
+}
 
 describe('AuthService', () => {
-  let service: AuthService;
+  let authService: AuthService;
+  let userRepository: UserRepository;
+  let jwtService: JwtService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        JwtService,
+        { provide: UserRepository, useClass: MockUserRepository },
+      ],
     }).compile();
 
-    service = module.get<AuthService>(AuthService);
+    authService = module.get<AuthService>(AuthService);
+    userRepository = module.get<UserRepository>(UserRepository);
+    jwtService = module.get<JwtService>(JwtService);
+
+    // Bcrypt Stub
+    jest
+      .spyOn(bcrypt, 'hash')
+      .mockImplementation((plain: string, salt = 10) =>
+        Promise.resolve(`${plain} hashed ${salt}`),
+      );
+
+    jest
+      .spyOn(bcrypt, 'compare')
+      .mockImplementation((plain, hashed) =>
+        Promise.resolve(`${plain} hashed 10` === hashed),
+      );
+
+    // JwtService Stub
+    jest
+      .spyOn(jwtService, 'verifyAsync')
+      .mockImplementation((mockAccessToken: string) => {
+        const subStr = mockAccessToken.split('_')[1];
+        return Promise.resolve({
+          sub: parseInt(subStr),
+        });
+      });
+
+    jest
+      .spyOn(jwtService, 'signAsync')
+      .mockImplementation((mockPayload: JwtPayload) =>
+        Promise.resolve(`token_${mockPayload.sub}`),
+      );
+
+    // UserRepository Stub
+    jest.spyOn(userRepository, 'isExist').mockImplementation((user: User) => {
+      if (user.email === 'new') {
+        return Promise.resolve(false);
+      } else if (user.email === 'already') {
+        return Promise.resolve(true);
+      } else if (user.id === 1) {
+        return Promise.resolve(true);
+      } else if (user.id > 1) {
+        return Promise.resolve(false);
+      }
+    });
+
+    jest
+      .spyOn(userRepository, 'findUserBy')
+      .mockImplementation((user: User) => {
+        if (user.email === 'already') {
+          const savedUser = new User();
+          savedUser.id = 1;
+          savedUser.email = 'already';
+          savedUser.password = 'already hashed 10';
+          return Promise.resolve(savedUser);
+        } else if (user.email === 'new') {
+          return Promise.resolve(null);
+        }
+      });
+
+    jest.spyOn(userRepository, 'save').mockImplementation((user: User) => {
+      user.id = 1;
+      user.setHashedPassword('new hashed 10');
+      return Promise.resolve(user);
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
-    expect(service).toBeDefined();
+    expect(authService).toBeDefined();
+    expect(userRepository).toBeDefined();
+    expect(jwtService).toBeDefined();
+  });
+
+  describe('signUp()', () => {
+    // 공통으로 사용되는 객체
+    const mockPayload = { sub: 1 };
+    const mockAccessToken = `token_${mockPayload.sub}`;
+
+    it('SUCCESS: 신규 유저라면 회원 가입 후 엑세스토큰 리턴', async () => {
+      // Given
+      const newUser = new User();
+      newUser.email = 'new';
+      newUser.password = 'new';
+
+      const expectedResult = new AccessTokenDto(mockAccessToken);
+
+      // When
+      const result = await authService.signUp(newUser);
+
+      // Then
+      expect(result).toBeInstanceOf(AccessTokenDto);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('FAILURE: 이미 가입되어 있는 유저라면 409 예외 throw', async () => {
+      // Given
+      const alreadyUser = new User();
+      alreadyUser.email = 'already';
+      alreadyUser.password = 'already';
+
+      // When & Then
+      await expect(async () => {
+        await authService.signUp(alreadyUser);
+      }).rejects.toThrowError(new ConflictException('이미 가입된 회원입니다.'));
+    });
+  });
+
+  describe('signIn()', () => {
+    // 공통으로 사용되는 객체
+    const mockPayload = { sub: 1 };
+    const mockAccessToken = `token_${mockPayload.sub}`;
+
+    it('SUCCESS: 올바른 이메일과 패스워드 입력 시 엑세스 토큰 반환', async () => {
+      // Given
+      const alreadyUser = new User();
+      alreadyUser.email = 'already';
+      alreadyUser.password = 'already';
+
+      const expectedResult = new AccessTokenDto(mockAccessToken);
+
+      // When
+      const result = await authService.signIn(alreadyUser);
+
+      // Then
+      expect(result).toBeInstanceOf(AccessTokenDto);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('FAILURE: 가입된 이메일이 아닐 때, 401 예외 throw', async () => {
+      // Given
+      const newUser = new User();
+      newUser.email = 'new';
+      newUser.password = 'new';
+
+      // When & Then
+      await expect(async () => {
+        await authService.signIn(newUser);
+      }).rejects.toThrowError(
+        new UnauthorizedException(
+          '로그인에 실패했습니다. 이메일과 비밀번호를 다시 입력해주세요.',
+        ),
+      );
+    });
+
+    it('FAILURE: 패스워드가 틀렸을 때, 401 예외 throw', async () => {
+      // Given
+      const wrongPasswordUser = new User();
+      wrongPasswordUser.email = 'already';
+      wrongPasswordUser.password = 'wrong';
+
+      // When & Then
+      await expect(async () => {
+        await authService.signIn(wrongPasswordUser);
+      }).rejects.toThrowError(
+        new UnauthorizedException(
+          '로그인에 실패했습니다. 이메일과 비밀번호를 다시 입력해주세요.',
+        ),
+      );
+    });
+  });
+
+  describe('getTokenPayload()', () => {
+    it('SUCCESS: 엑세스 토큰의 페이로드에 있는 sub 클레임이 회원의 id인 경우 페이로드 리턴', async () => {
+      // Given
+      const requestUser = new User();
+      requestUser.email = 'already';
+      const savedUser = await userRepository.findUserBy(requestUser);
+
+      const mockAccessToken = `token_${savedUser.id}`;
+      const expectedResult: JwtPayload = { sub: savedUser.id };
+
+      // When
+      const result = await authService.getTokenPayload(mockAccessToken);
+
+      // Then
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('FAILURE: 엑세스 토큰의 페이로드에 있는 유저 id가 회원이 아닌 경우 에러 throw', async () => {
+      // Given
+      const weirdUser = User.byId(22222);
+      const weirdAccessToken = `token_${weirdUser.id}`;
+
+      // When & Then
+      await expect(async () => {
+        await authService.getTokenPayload(weirdAccessToken);
+      }).rejects.toThrowError(new Error('존재하지 않는 유저입니다.'));
+    });
   });
 });

--- a/src/auth/decorator/swagger/sign-up.decorator.ts
+++ b/src/auth/decorator/swagger/sign-up.decorator.ts
@@ -5,7 +5,7 @@ import {
   ApiCreatedResponse,
   ApiOperation,
 } from '@nestjs/swagger';
-import { SignUpDto } from 'src/auth/dto/sign-up.dto';
+import { SignUpDto } from './../../dto/sign-up.dto';
 
 export const SwaggerSignUp = (): MethodDecorator =>
   applyDecorators(

--- a/src/auth/dto/sign-in.dto.ts
+++ b/src/auth/dto/sign-in.dto.ts
@@ -4,12 +4,11 @@ import { SignUpDto } from './sign-up.dto';
 
 export class SignInDto extends PickType(SignUpDto, ['email', 'password']) {
   toEntity(): User {
-    const user = new User();
+    const props = {
+      email: this.email,
+      password: this.password,
+    };
 
-    Object.entries(this).forEach(([key, value]) => {
-      user[key] = value;
-    });
-
-    return user;
+    return User.of(props);
   }
 }

--- a/src/auth/dto/sign-up.dto.spec.ts
+++ b/src/auth/dto/sign-up.dto.spec.ts
@@ -1,29 +1,27 @@
 import { User } from '../../user/entity/user.entity';
 import { SignUpDto } from './sign-up.dto';
 
-describe('sign-up-req.dto.ts', () => {
-  describe('SignUpReqDto', () => {
-    describe('toEntity', () => {
-      it('SUCCESS: Request Body에 올바른 값이 전달되었을 때 그 필드들을 가진 user 엔티티 리턴', () => {
-        // When
-        const signUpReqDto = new SignUpDto();
-        signUpReqDto.email = 'feed-me-admin1@naver.com';
-        signUpReqDto.password = 'Feed-me1!';
-        signUpReqDto.city = '서울특별시';
-        signUpReqDto.isRecommendateLunch = true;
+describe('SignUpDto', () => {
+  describe('toEntity()', () => {
+    it('SUCCESS: Request Body에 올바른 값이 전달되었을 때 그 필드들을 가진 user 엔티티 리턴', () => {
+      // Given
+      const signUpDto = new SignUpDto();
+      signUpDto.email = 'feed-me-admin1@naver.com';
+      signUpDto.password = 'Feed-me1!';
+      signUpDto.city = '서울특별시';
+      signUpDto.isRecommendateLunch = true;
 
-        // When
-        const expectedResult = signUpReqDto.toEntity();
+      // When
+      const expectedResult = signUpDto.toEntity();
 
-        // Then
-        expect(expectedResult).toBeInstanceOf(User);
-        expect(expectedResult.email).toBe<string>(signUpReqDto.email);
-        expect(expectedResult.password).toBe<string>(signUpReqDto.password);
-        expect(expectedResult.city).toBe<string>(signUpReqDto.city);
-        expect(expectedResult.isRecommendateLunch).toBe<boolean>(
-          signUpReqDto.isRecommendateLunch,
-        );
-      });
+      // Then
+      expect(expectedResult).toBeInstanceOf(User);
+      expect(expectedResult.email).toBe<string>(signUpDto.email);
+      expect(expectedResult.password).toBe<string>(signUpDto.password);
+      expect(expectedResult.city).toBe<string>(signUpDto.city);
+      expect(expectedResult.isRecommendateLunch).toBe<boolean>(
+        signUpDto.isRecommendateLunch,
+      );
     });
   });
 });

--- a/src/auth/dto/sign-up.dto.ts
+++ b/src/auth/dto/sign-up.dto.ts
@@ -10,7 +10,7 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
-import { User } from '../../user/entity/user.entity';
+import { User, UserCreateProps } from '../../user/entity/user.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class SignUpDto {
@@ -98,12 +98,15 @@ export class SignUpDto {
   isRecommendateLunch: boolean;
 
   toEntity(): User {
-    const user = new User();
+    const userProps: UserCreateProps = {
+      email: this.email,
+      password: this.password,
+      city: this.city,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      isRecommendateLunch: this.isRecommendateLunch,
+    };
 
-    Object.entries(this).forEach(([key, value]) => {
-      user[key] = value;
-    });
-
-    return user;
+    return User.create(userProps);
   }
 }

--- a/src/user/dto/update-user.dto.spec.ts
+++ b/src/user/dto/update-user.dto.spec.ts
@@ -1,29 +1,25 @@
-import { User } from '../entity/user.entity';
 import { UpdateUserDto } from './update-user.dto';
+import { User } from '../entity/user.entity';
 
-describe('sign-up-req.dto.ts', () => {
-  describe('UpdateUserReqDto', () => {
-    describe('toEntity', () => {
-      it('SUCCESS: Request Body에 올바른 값이 전달되었을 때 그 필드들을 가진 user 엔티티 리턴', () => {
-        // When
-        const updateUserReqDto = new UpdateUserDto();
-        updateUserReqDto.latitude = 37.566295;
-        updateUserReqDto.longitude = 126.977945;
-        updateUserReqDto.isRecommendateLunch = true;
+describe('UpdateUserDto', () => {
+  describe('toEntity()', () => {
+    it('SUCCESS: Request Body에 올바른 값이 전달되었을 때 그 필드들을 가진 user 엔티티 리턴', () => {
+      // Given
+      const updateUserDto = new UpdateUserDto();
+      updateUserDto.latitude = 37.566295;
+      updateUserDto.longitude = 126.977945;
+      updateUserDto.isRecommendateLunch = true;
 
-        // When
-        const expectedResult = updateUserReqDto.toEntity();
+      // When
+      const expectedResult = updateUserDto.toEntity();
 
-        // Then
-        expect(expectedResult).toBeInstanceOf(User);
-        expect(expectedResult.latitude).toBe<number>(updateUserReqDto.latitude);
-        expect(expectedResult.longitude).toBe<number>(
-          updateUserReqDto.longitude,
-        );
-        expect(expectedResult.isRecommendateLunch).toBe<boolean>(
-          updateUserReqDto.isRecommendateLunch,
-        );
-      });
+      // Then
+      expect(expectedResult).toBeInstanceOf(User);
+      expect(expectedResult.latitude).toBe<number>(updateUserDto.latitude);
+      expect(expectedResult.longitude).toBe<number>(updateUserDto.longitude);
+      expect(expectedResult.isRecommendateLunch).toBe<boolean>(
+        updateUserDto.isRecommendateLunch,
+      );
     });
   });
 });

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -5,7 +5,7 @@ import {
   IsLongitude,
   IsNotEmpty,
 } from 'class-validator';
-import { User } from '../entity/user.entity';
+import { UserUpdateProps } from '../entity/user.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateUserDto {
@@ -39,12 +39,11 @@ export class UpdateUserDto {
   @IsBoolean()
   isRecommendateLunch: boolean;
 
-  toEntity(): User {
-    const user = new User();
-    user.latitude = this.latitude;
-    user.longitude = this.longitude;
-    user.isRecommendateLunch = this.isRecommendateLunch;
-
-    return user;
+  getProps(): UserUpdateProps {
+    return {
+      latitude: this.latitude,
+      longitude: this.longitude,
+      isRecommendateLunch: this.isRecommendateLunch,
+    };
   }
 }

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -8,6 +8,24 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+export interface UserCreateProps {
+  email: string;
+  password: string;
+  city: string;
+  latitude: number;
+  longitude: number;
+  isRecommendateLunch: boolean;
+}
+
+export interface UserSignInProps
+  extends Pick<UserCreateProps, 'email' | 'password'> {}
+
+export interface UserUpdateProps {
+  latitude: number;
+  longitude: number;
+  isRecommendateLunch: boolean;
+}
+
 @Entity('users')
 @Unique(['email'])
 export class User {
@@ -65,6 +83,49 @@ export class User {
   static byId(id: number): User {
     const user = new User();
     user.id = id;
+    return user;
+  }
+
+  static create({
+    email,
+    password,
+    city,
+    latitude,
+    longitude,
+    isRecommendateLunch,
+  }: UserCreateProps): User {
+    const user = new User();
+
+    user.email = email;
+    user.password = password;
+    user.city = city;
+    user.latitude = latitude;
+    user.longitude = longitude;
+    user.isRecommendateLunch = isRecommendateLunch;
+
+    return user;
+  }
+
+  static of({ email, password }: UserSignInProps): User {
+    const user = new User();
+
+    user.email = email;
+    user.password = password;
+
+    return user;
+  }
+
+  static updateBy({
+    latitude,
+    longitude,
+    isRecommendateLunch,
+  }: UserUpdateProps): User {
+    const user = new User();
+
+    user.latitude = latitude;
+    user.longitude = longitude;
+    user.isRecommendateLunch = isRecommendateLunch;
+
     return user;
   }
 

--- a/src/user/repository/user.repository.ts
+++ b/src/user/repository/user.repository.ts
@@ -25,7 +25,7 @@ export class UserRepository {
   }
 
   async findUserBy(user: User): Promise<User> {
-    const where: FindUserOptionWhere = this.getFindUserOptionsWhere(user);
+    const where = this.getFindUserOptionsWhere(user);
     return await this.userRepository.findOne({ where });
   }
 

--- a/src/user/repository/user.repository.ts
+++ b/src/user/repository/user.repository.ts
@@ -1,9 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, FindOptionsWhere } from 'typeorm';
 import { User } from '../entity/user.entity';
 
-export type Identifier = { id: number } | { email: string };
+export type FindUserOptionWhere =
+  | { id: number }
+  | { email: string } extends FindOptionsWhere<User>
+  ? { id: number } | { email: string }
+  : never;
 
 @Injectable()
 export class UserRepository {
@@ -11,32 +15,38 @@ export class UserRepository {
     @InjectRepository(User) private readonly userRepository: Repository<User>,
   ) {}
 
-  async createUser(user: User): Promise<User> {
+  async save(user: User): Promise<User> {
     return await this.userRepository.save(user);
   }
 
-  /**
-   * @author 명석
-   * @param identifier 유저를 db에서 조회할 때 사용하는 식별자(identifier)입니다. user의 식별자는 email(unique key, string) 또는 id(primary key, number)이고 두 식별자 모두를 함수 인자로 받아 사용할 수 있도록 구현했습니다.
-   * @returns boolean을 Promise로 반환합니다.
-   */
-  async isExistBy(identifier: Identifier): Promise<boolean> {
-    return await this.userRepository.exist({
-      where: identifier,
-    });
+  async isExist(user: User): Promise<boolean> {
+    const where: FindUserOptionWhere = this.getFindUserOptionsWhere(user);
+    return await this.userRepository.exist({ where });
   }
 
-  /**
-   * @author 명석
-   * @param identifier 유저를 db에서 조회할 때 사용하는 식별자(identifier)입니다. user의 식별자는 email(unique key, string) 또는 id(primary key, number)이고 두 식별자 모두를 함수 인자로 받아 사용할 수 있도록 구현했습니다.
-   * @returns User 엔티티를 Promise로 반환합니다. user가 없을 경우 null을 반환합니다.
-   */
-  async findUserBy(identifier: Identifier): Promise<User> {
-    return await this.userRepository.findOne({ where: identifier });
+  async findUserBy(user: User): Promise<User> {
+    const where: FindUserOptionWhere = this.getFindUserOptionsWhere(user);
+    return await this.userRepository.findOne({ where });
   }
 
   async updateUser(userId: number, user: User): Promise<boolean> {
     const result = await this.userRepository.update({ id: userId }, user);
     return result.affected > 0;
+  }
+
+  /**
+   * @author 명석
+   * @param identifier 유저를 db에서 조회할 때 사용하는 식별자(identifier)입니다. user의 식별자는 email(unique key, string) 또는 id(primary key, number)이고 두 식별자 모두를 함수 인자로 받아 사용할 수 있도록 구현했습니다. id가 있다면 id를 우선 식별자로 리턴합니다.
+   * @returns boolean을 Promise로 반환합니다.
+   */
+  private getFindUserOptionsWhere(user: User): FindUserOptionWhere {
+    let identifier: FindUserOptionWhere;
+
+    if (user.hasOwnProperty('id')) {
+      identifier = { id: user.id };
+    } else if (user.hasOwnProperty('email')) {
+      identifier = { email: user.email };
+    }
+    return identifier;
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -31,7 +31,8 @@ export class UserController {
     @UserId() userId: number,
     @Body() dto: UpdateUserDto,
   ): Promise<ResponseEntity<string>> {
-    await this.userService.updateUser(userId, dto.toEntity());
+    await this.userService.updateUser(userId, dto.getProps());
+    // todo 204 no content로 상태코드 변경 예정
     return ResponseEntity.OK('사용자 설정 업데이트 요청에 성공했습니다');
   }
 }

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -68,7 +68,7 @@ describe('UserService', () => {
       const userInDb = await userRepository.findUserBy(
         User.byId(alreadyUserId),
       );
-      console.log('userInDb: ', userInDb);
+
       const expectedResult = new GetUserResDto(userInDb);
 
       // When

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,18 +1,127 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
+import { UserRepository } from './repository/user.repository';
+import { User } from './entity/user.entity';
+import { GetUserResDto } from './dto/get-user-res.dto';
+import { NotFoundException } from '@nestjs/common';
+
+// DB 의존성 Mock
+class MockUserRepository {
+  findUserBy = jest.fn();
+  updateUser = jest.fn();
+}
 
 describe('UserService', () => {
-  let service: UserService;
+  let userService: UserService;
+  let userRepository: UserRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        { provide: UserRepository, useClass: MockUserRepository },
+      ],
     }).compile();
 
-    service = module.get<UserService>(UserService);
+    userService = module.get<UserService>(UserService);
+    userRepository = module.get<UserRepository>(UserRepository);
+
+    // UserRepository Stub
+    jest
+      .spyOn(userRepository, 'findUserBy')
+      .mockImplementation((user: User) => {
+        if (user.id === 1) {
+          const savedUser = new User();
+          savedUser.id = 1;
+          savedUser.email = 'already';
+          savedUser.password = 'already hashed 10';
+          return Promise.resolve(savedUser);
+        } else if (user.id > 1) {
+          return Promise.resolve(null);
+        }
+      });
+
+    jest
+      .spyOn(userRepository, 'updateUser')
+      .mockImplementation((userId: number) => {
+        if (userId === 1) {
+          return Promise.resolve(true);
+        } else if (userId > 1) {
+          return Promise.resolve(false);
+        }
+      });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
-    expect(service).toBeDefined();
+    expect(userService).toBeDefined();
+    expect(userRepository).toBeDefined();
+  });
+
+  describe('getUser()', () => {
+    it('SUCCESS: 유저 id가 db에 존재하면 DB의 유저 정보를 DTO에 담아 리턴', async () => {
+      // Given
+      const alreadyUserId = 1;
+      const userInDb = await userRepository.findUserBy(
+        User.byId(alreadyUserId),
+      );
+      console.log('userInDb: ', userInDb);
+      const expectedResult = new GetUserResDto(userInDb);
+
+      // When
+      const result = await userService.getUser(alreadyUserId);
+
+      // Then
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('FAILURE: 유저가 존재하지 않으면 404 에러 Throw', async () => {
+      // Given
+      const notUserId = 22222;
+
+      // When & Then
+      expect(async () => {
+        await userService.getUser(notUserId);
+      }).rejects.toThrowError(
+        new NotFoundException('유저가 존재하지 않습니다.'),
+      );
+    });
+  });
+
+  describe('updateUser()', () => {
+    const userUpdateProps = {
+      latitude: 37.6,
+      longitude: 126.24,
+      isRecommendateLunch: true,
+    };
+
+    it('SUCCESS: 유저 id가 db에 존재하면 전달 받은 정보로 DB 업데이트(void)', async () => {
+      // Given
+      const alreadyUserId = 1;
+
+      // When
+      const result = await userService.updateUser(
+        alreadyUserId,
+        userUpdateProps,
+      );
+
+      // Then
+      expect(result).toBe('사용자 정보 업데이트 성공');
+    });
+
+    it('FAILURE: 유저가 존재하지 않으면 404 에러 Throw', async () => {
+      // Given
+      const notUserId = 22222;
+
+      // When & Then
+      expect(async () => {
+        await userService.updateUser(notUserId, userUpdateProps);
+      }).rejects.toThrowError(
+        new NotFoundException('유저가 존재하지 않습니다.'),
+      );
+    });
   });
 });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { UserRepository } from './repository/user.repository';
-import { User } from './entity/user.entity';
+import { User, UserUpdateProps } from './entity/user.entity';
 import { GetUserResDto } from './dto/get-user-res.dto';
 
 @Injectable()
@@ -8,13 +8,18 @@ export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
   async getUser(userId: number): Promise<GetUserResDto> {
-    const user = await this.userRepository.findUserBy({ id: userId });
+    const user = await this.userRepository.findUserBy(User.byId(userId));
     if (user === null) throw new NotFoundException('유저가 존재하지 않습니다.');
     return new GetUserResDto(user);
   }
 
-  async updateUser(userId: number, partialUser: User): Promise<void> {
-    const isUpdated = await this.userRepository.updateUser(userId, partialUser);
+  async updateUser(userId: number, props: UserUpdateProps): Promise<string> {
+    const isUpdated = await this.userRepository.updateUser(
+      userId,
+      User.updateBy(props),
+    );
     if (!isUpdated) throw new NotFoundException('유저가 존재하지 않습니다.');
+
+    return '사용자 정보 업데이트 성공';
   }
 }


### PR DESCRIPTION
## PR 체크리스트
아래 항목을 확인해 주세요:

- [ ] 커밋 메시지가 우리의 가이드라인을 따르고 있는지 확인하세요
- [ ] 변경 사항에 대한 테스트가 추가되었는지 확인하세요 (버그 수정 / 기능 추가)
- [ ] 문서가 추가되거나 업데이트되었는지 확인하세요 (버그 수정 / 기능 추가)

## PR 유형
이 PR은 어떤 종류의 변경을 가져오나요?

- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 코드 스타일 업데이트 (서식, 로컬 변수)
- [x] 리팩터링 (기능 변경 없음, API 변경 없음)
- [ ] 빌드 관련 변경
- [ ] CI 관련 변경
- [ ] 문서 내용 변경
- [ ] 애플리케이션 / 인프라 변경
- [ ] 기타... 설명:

## 관련 이슈

이슈 번호: #28 

## 현재 동작은 무엇인가요?

## 새로운 동작은 무엇인가요?

### [Test : 회원가입 dto 테스트 코드 작성](https://github.com/pre-onboarding-backend-G/feed-me-baby/commit/8b6e6eecf3a27fbb1bec7e4bf3438cc92dd58dd3)

### [Test : 유저 정보 수정 API dto의 테스트 코드 작성](https://github.com/pre-onboarding-backend-G/feed-me-baby/commit/1eaf295358202fab708b13204298ef2a6a7e1fad)

### [Feat : Auth service unit test 추가](https://github.com/pre-onboarding-backend-G/feed-me-baby/commit/714a078b0f856fecb6ea6354382f1fc1922fa662) https://github.com/pre-onboarding-backend-G/feed-me-baby/issues/28 

AuthService 클래스의 메소드를 테스트하는 유닛 테스트 코드를 작성했습니다.

**[AuthService 리펙토링]**
- private 메소드를 제거했습니다. 제가 private 메소드들로 따로 분리하여 작성한 이유는 캡슐화, 그리고 코드의 가독성이었습니다. 때로는 복잡한 로직이 함수내부에 나열되면 함수 내부 작동을 파악하기 어렵습니다. 따라서 하나의 기능만을 갖도록 함수를 쪼개고, 함수명을 절차적으로 바꿔주면 가독성이 좋아질 것으로 생각했고, 그 생각은 틀리지 않았던 것 같습니다.
- 하지만, 그럼에도 불구하고 private 메소드들을 삭제했습니다.
- 논외로, private 메소드는 오히려 테스트 코드 작성을 피하라는 지침도 보았습니다. 만약 테스트가 필요한 코드라면 public 선언을 하거나, private로 캡슐화 하고자 했던 의도를 살려, 별도의 도메인 클래스로 분리하여 service 테스트에서는 테스트의 범위에 넣지 않는 것이 올바른 방식이라는 것을 알게 되었습니다.
- 이제 제가 private 메소드를 삭제한 '진짜' 이유는 다음과 같습니다.

> 1. 캡슐화의 의미가 무색하며, 가독성이 그렇게 좋아진 것도 아니다.
> 2. 함수 내부에서 사용하는 메소드들이 private 선언 되어있는데, 외부 의존성까지 사용하고 있다면, 본 함수의 테스트 코드 작성이 "어색하고 불편하다"는 것입니다.
>> - private 선언한 함수들은 "전부" 빠짐없이 외부 의존성을 사용하고 있었습니다. 테스트 코드를 작성하려면 외부 의존성을 테스트 더블로 대체해야 합니다.
>> - 그런데 메서드에 private 접근제한자를 했다는 것은, 추상화 하여 내부 로직을 숨기겠다는 의미인데 의존성을 테스트 더블로 처리하려면 추상화된 메서드의 내부 로직을 보고 모킹을 해야 합니다. 즉, 테스트코드를 작성하기 위해 감춰진 메소드의 구현부를 상세히 알아야 하는 모순이 생깁니다.
>> - 또한, 이런 모순을 가진채 테스트코드를 작성하게 되면, 다른 사람 또는, 작성자가 오랜 시간 후에 유지보수를 위해 테스트 코드와 본 기능의 코드를 함께 읽어 내려갈 때 가독성이 현저히 떨어지게 됩니다. 그러므로 작성된 테스트 코드가 테스트에 통과하더라도 정말 제대로 테스트가 된 것 인지 신뢰하기 어렵게 된다고 생각합니다.

**이러한 이유로, private 선언된 메소드들은 본 기능의 함수로 로직을 재배치 했습니다. 그리고, isExistUser 함수의 경우, 동적 쿼리를 생산하는 기능을 repository 단으로 옮겨 서비스에서는 해당 동작에 대해 알 필요가 없게 했습니다. 이 상태에서 테스트 코드 작성을 시작했습니다.**

- 참고자료 : https://jojoldu.tistory.com/681

**[AuthService 테스트코드]**
- authService의 signUp, signIn, getTokenPayload 함수들은, 사실 외부 의존성만으로 이루어진 함수입니다. 따라서 테스트 코드를 작성할 때, "전적으로" 테스트 더블에 의존합니다.(테스트 더블이 무엇인지는 11월 6일 TIL에서 확인 해주세요)
- 따라서, 애초에 테스트 하기 좋은 코드로 개선할 수 없는 지경의 코드입니다. 테스트 하기 좋은 코드로 리펙토링 하기 위해 도메인 로직으로 최대한 뺄 수 있는게 뭘까 고민하며 이리저리 클래스를 만들었다 지웠다 혼자 난리법석을 피웠지만 결국 방법이 없었습니다.(https://jojoldu.tistory.com/676 이 글을 참고했었습니다) 결국 테스트 더블에 의존하기로 합니다. 그 중에서도 Mock이 아닌 Stub을 사용했습니다.
- Stub은 Jest에서 지원하고 있는 테스트 더블은 아닙니다. 하지만, Spy로 우회하여 구현할 수 있기 때문에 jest의 spyOn 메소드를 아주 적극적으로 활용했습니다.
- 테스트 코드를 보시면 행위를 검증하는 코드가 없습니다. toBeCalled, toBeCalledWith 등등이 행위를 검증하는 코드입니다. 이런 코드들이 없는 이유는 있을 필요가 없게 stub 객체를 만들었기 때문입니다.
- stub 객체를 보시면, 실제 코드와 거의 동일한 input과 output이 나오도록 만들었습니다. 사실상 테스트를 하기 위해 외부 의존성을 다 빼고 실제 코드와 동일한 결과(상태)를 얻도록 만드는 것이 Stub 객체입니다. 따라서, 올바르게 Stub을 구현했다면 행위 검증은 필요 없는 것이 되고, 결국 service 메소드의 인자와 아웃풋이 내가 의도한 것과 같은가만 확인하면 되기 때문에, 테스트 코드 자체만을 읽을 때 명료하고 가독성이 좋습니다.
- 물론 단점은 있습니다. mock이든 stub이든 테스트 더블 처리한 코드의 구현부를 상세하게 의존하기 때문입니다. 실제 구현부가 달라지면 테스트 코드가 수정되어야 하므로 변경에 굉장히 취약합니다.
- 그러나, 테스트 더블을 사용할 수 밖에 없는 상태라면 mock 보다는 stub이 최선이기에 stub을 선택했습니다.

[참고자료]
- https://jojoldu.tistory.com/637
- https://jojoldu.tistory.com/638
- https://jojoldu.tistory.com/656
- https://jojoldu.tistory.com/680
- https://jojoldu.tistory.com/676

### [Test : User Service 테스트 코드 작성](https://github.com/pre-onboarding-backend-G/feed-me-baby/pull/32/commits/a95e4b7a0b1851ee42d1aa3345ec8bd17dcf0e35) https://github.com/pre-onboarding-backend-G/feed-me-baby/issues/28 

[코드 리펙토링]
- user 도메인 엔티티에, 유저를 생성하고, 업데이트하고 회원가입에 사용하는 도메인 메소드를 정적 메소드로 추가했습니다.
- 도메인 엔티티 추가로 signUp과 signIn, updateUser dto의 메소드 변경
- updateUser 메소드에 return 메시지를 추가했습니다. 리턴 값이 없는 함수는 테스트가 어려웠습니다.
- userService에서는 User의 메소드를 사용하도록 코드 수정

[테스트 코드]
- userRepository의 stub을 구성하여 테스트 코드 작성


## 이 PR은 호환성 변경을 도입하나요?

- [ ] 예
- [ ] 아니요

<!-- 이 PR에 호환성 변경이 포함되어 있다면, 기존 응용 프로그램에 대한 영향과 마이그레이션 경로를 아래에 설명해 주세요. -->

## 기타 정보
